### PR TITLE
40/feat/대시보드 레이아웃헤더

### DIFF
--- a/src/apis/dashboards/index.ts
+++ b/src/apis/dashboards/index.ts
@@ -1,12 +1,22 @@
 import axiosClientHelper from "@/utils/network/axiosClientHelper";
 import { safeResponse } from "@/utils/network/safeResponse";
 import {
+  Dashboard,
   Dashboards,
   dashboardSchema,
   GetDashboardsRequest,
   getDashboardsResponseSchema,
   PostDashboardsFormData,
 } from "./types";
+
+/**
+ * 대시보드 생성
+ * https://sp-taskify-api.vercel.app/docs/#/dashboards
+ */
+export const postDashboards = async (data: PostDashboardsFormData) => {
+  const response = await axiosClientHelper.post("/dashboards", data);
+  return safeResponse(response.data, dashboardSchema);
+};
 
 /**
  * 대시보드 목록 조회
@@ -26,10 +36,12 @@ export const getDashboards = async (params: GetDashboardsRequest) => {
 };
 
 /**
- * 대시보드 생성
- * https://sp-taskify-api.vercel.app/docs/#/dashboards
+ * 대시보드 상세 조회
+ * https://sp-taskify-api.vercel.app/docs/#/dashboards/{dashboardId}
  */
-export const postDashboards = async (data: PostDashboardsFormData) => {
-  const response = await axiosClientHelper.post("/dashboards", data);
+export const getDashboard = async (dashboardId: number) => {
+  const response = await axiosClientHelper.get<Dashboard>(
+    `/dashboards/${dashboardId}`
+  );
   return safeResponse(response.data, dashboardSchema);
 };

--- a/src/apis/dashboards/queries.ts
+++ b/src/apis/dashboards/queries.ts
@@ -1,11 +1,18 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { GetDashboardsRequest, PostDashboardsFormData } from "./types";
-import { getDashboards, postDashboards } from ".";
+import { getDashboard, getDashboards, postDashboards } from ".";
 
 export const useGetDashboardsQuery = (params: GetDashboardsRequest) => {
   return useQuery({
     queryKey: ["dashboards", params],
     queryFn: () => getDashboards(params),
+  });
+};
+
+export const useGetDashboardQuery = (dashboardId: number) => {
+  return useQuery({
+    queryKey: ["dashboard", dashboardId],
+    queryFn: () => getDashboard(dashboardId),
   });
 };
 

--- a/src/components/dashboard/header/AvatarStack.tsx
+++ b/src/components/dashboard/header/AvatarStack.tsx
@@ -1,7 +1,6 @@
 import { useGetMembers } from "@/apis/members/queries";
 import { Member } from "@/apis/members/types";
 import Avatar from "@/components/ui/Avatar";
-import getRandomColor from "@/utils/getRandomColor";
 
 const AvatarStack = ({ dashboardId }: { dashboardId: number }) => {
   const { data } = useGetMembers({
@@ -11,26 +10,23 @@ const AvatarStack = ({ dashboardId }: { dashboardId: number }) => {
   });
   console.log("멤버 데이터", data);
 
-  const getVisibleCount = () => {
-    if (window.innerWidth < 768) {
-      return 2;
-    }
-    return 4;
-  };
-
-  const visibleMembers = data?.members.slice(0, getVisibleCount());
-  const remainMembers = data?.totalCount! - getVisibleCount();
+  const visibleMembers = data?.members.slice(0, 4);
+  const remainMembers = data?.totalCount! - 4;
 
   return (
     <div className="flex items-center -space-x-2.5">
       {visibleMembers &&
-        visibleMembers.map((member: Member) => (
-          <Avatar
+        visibleMembers.map((member: Member, index: number) => (
+          <div
             key={member.id}
-            profileImageUrl={member.profileImageUrl}
-            nickname={member.nickname}
-            email={member.email}
-          />
+            className={`${index >= 2 ? "hidden md:block" : ""}`}
+          >
+            <Avatar
+              profileImageUrl={member.profileImageUrl}
+              nickname={member.nickname}
+              email={member.email}
+            />
+          </div>
         ))}
       {remainMembers > 0 && (
         <div className="w-[34px] md:w-[38px] flex items-center justify-center border-2 border-white font-semibold text-[#D25B68] aspect-square rounded-full bg-[#F4D7DA]">

--- a/src/components/dashboard/header/AvatarStack.tsx
+++ b/src/components/dashboard/header/AvatarStack.tsx
@@ -8,10 +8,9 @@ const AvatarStack = ({ dashboardId }: { dashboardId: number }) => {
     page: 1,
     size: 10,
   });
-  console.log("멤버 데이터", data);
 
   const visibleMembers = data?.members.slice(0, 4);
-  const remainMembers = data?.totalCount! - 4;
+  const remainMembers = data!.totalCount - 4;
 
   return (
     <div className="flex items-center -space-x-2.5">

--- a/src/components/dashboard/header/AvatarStack.tsx
+++ b/src/components/dashboard/header/AvatarStack.tsx
@@ -1,0 +1,44 @@
+import { useGetMembers } from "@/apis/members/queries";
+import { Member } from "@/apis/members/types";
+import Avatar from "@/components/ui/Avatar";
+import getRandomColor from "@/utils/getRandomColor";
+
+const AvatarStack = ({ dashboardId }: { dashboardId: number }) => {
+  const { data } = useGetMembers({
+    dashboardId,
+    page: 1,
+    size: 10,
+  });
+  console.log("멤버 데이터", data);
+
+  const getVisibleCount = () => {
+    if (window.innerWidth < 768) {
+      return 2;
+    }
+    return 4;
+  };
+
+  const visibleMembers = data?.members.slice(0, getVisibleCount());
+  const remainMembers = data?.totalCount! - getVisibleCount();
+
+  return (
+    <div className="flex items-center -space-x-2.5">
+      {visibleMembers &&
+        visibleMembers.map((member: Member) => (
+          <Avatar
+            key={member.id}
+            profileImageUrl={member.profileImageUrl}
+            nickname={member.nickname}
+            email={member.email}
+          />
+        ))}
+      {remainMembers > 0 && (
+        <div className="w-[34px] md:w-[38px] flex items-center justify-center border-2 border-white font-semibold text-[#D25B68] aspect-square rounded-full bg-[#F4D7DA]">
+          +{remainMembers}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AvatarStack;

--- a/src/components/dashboard/header/DashBoardInfo.tsx
+++ b/src/components/dashboard/header/DashBoardInfo.tsx
@@ -1,15 +1,18 @@
-import Button from "@/components/ui/Button";
 import HeaderButton from "./HeaderButton";
+import AvatarStack from "./AvatarStack";
 
-const DashBoardInfo = () => {
+const DashBoardInfo = ({ dashboardId }: { dashboardId: number }) => {
   return (
-    <div className="flex gap-1.5 md:gap-4">
-      <HeaderButton href="#" icon="/column/setting-icon.svg">
-        관리
-      </HeaderButton>
-      <HeaderButton href="#" icon="/dashboard/add-icon.svg">
-        초대하기
-      </HeaderButton>
+    <div className="flex items-center gap-8">
+      <div className="flex gap-1.5 md:gap-4">
+        <HeaderButton href="#" icon="/column/setting-icon.svg">
+          관리
+        </HeaderButton>
+        <HeaderButton href="#" icon="/dashboard/add-icon.svg">
+          초대하기
+        </HeaderButton>
+      </div>
+      <AvatarStack dashboardId={dashboardId} />
     </div>
   );
 };

--- a/src/components/dashboard/header/DashBoardInfo.tsx
+++ b/src/components/dashboard/header/DashBoardInfo.tsx
@@ -1,10 +1,15 @@
 import Button from "@/components/ui/Button";
+import HeaderButton from "./HeaderButton";
 
 const DashBoardInfo = () => {
   return (
     <div className="flex gap-1.5 md:gap-4">
-      <Button>관리</Button>
-      <Button>초대하기</Button>
+      <HeaderButton href="#" icon="/column/setting-icon.svg">
+        관리
+      </HeaderButton>
+      <HeaderButton href="#" icon="/dashboard/add-icon.svg">
+        초대하기
+      </HeaderButton>
     </div>
   );
 };

--- a/src/components/dashboard/header/DashBoardInfo.tsx
+++ b/src/components/dashboard/header/DashBoardInfo.tsx
@@ -3,7 +3,7 @@ import AvatarStack from "./AvatarStack";
 
 const DashBoardInfo = ({ dashboardId }: { dashboardId: number }) => {
   return (
-    <div className="flex items-center gap-8">
+    <div className="flex items-center justify-between gap-8">
       <div className="flex gap-1.5 md:gap-4">
         <HeaderButton href="#" icon="/column/setting-icon.svg">
           관리

--- a/src/components/dashboard/header/Header.tsx
+++ b/src/components/dashboard/header/Header.tsx
@@ -1,12 +1,19 @@
 "use client";
 
+import { useGetDashboardQuery } from "@/apis/dashboards/queries";
 import DashBoardInfo from "./DashBoardInfo";
 import Profile from "./Profile";
+import { useParams } from "next/navigation";
 
 const Header = () => {
+  const params = useParams();
+  const { data } = useGetDashboardQuery(Number(params.id));
+  console.log("헤더데이터", data);
   return (
     <div className="flex justify-between items-center px-3 md:px-8 lg:px-10 py-4 border-b border-b-gray-200">
-      <p className="text-lg md:text-xl text-[#333236] font-bold">내 대시보드</p>
+      <p className="text-lg md:text-xl text-[#333236] font-bold">
+        {params.id ? data!.title : "내 대시보드"}
+      </p>
       <div className="flex gap-4 md:gap-9 divide-x divide-gray-300">
         <div className="flex pr-4 md:pr-9 items-center">
           <DashBoardInfo />

--- a/src/components/dashboard/header/Header.tsx
+++ b/src/components/dashboard/header/Header.tsx
@@ -7,16 +7,15 @@ import { useParams } from "next/navigation";
 
 const Header = () => {
   const params = useParams();
-  const { data } = useGetDashboardQuery(Number(params.id));
-  console.log("헤더데이터", data);
+  const { data: dashboardData } = useGetDashboardQuery(Number(params.id));
   return (
     <div className="flex justify-between items-center px-3 md:px-8 lg:px-10 py-4 border-b border-b-gray-200">
-      <p className="text-lg md:text-xl text-[#333236] font-bold">
-        {params.id ? data!.title : "내 대시보드"}
+      <p className="text-lg md:hidden text-[#333236] font-bold">
+        {dashboardData?.title || "내 대시보드"}
       </p>
       <div className="flex gap-4 md:gap-9 divide-x divide-gray-300">
         <div className="flex pr-4 md:pr-9 items-center">
-          <DashBoardInfo />
+          {dashboardData && <DashBoardInfo dashboardId={dashboardData.id} />}
         </div>
         <div className="flex">
           <Profile />

--- a/src/components/dashboard/header/Header.tsx
+++ b/src/components/dashboard/header/Header.tsx
@@ -9,15 +9,16 @@ const Header = () => {
   const params = useParams();
   const { data: dashboardData } = useGetDashboardQuery(Number(params.id));
   return (
-    <div className="flex justify-between items-center px-3 md:px-8 lg:px-10 py-4 border-b border-b-gray-200">
-      <p className="text-lg md:hidden text-[#333236] font-bold">
+    <div className="w-full flex items-center md:justify-end lg:justify-between  px-3 md:px-8 lg:px-10 py-4 border-b border-b-gray-200">
+      <div className="text-lg md:hidden lg:block truncate text-[#333236] font-bold">
         {dashboardData?.title || "내 대시보드"}
-      </p>
-      <div className="flex gap-4 md:gap-9 divide-x divide-gray-300">
+        {}
+      </div>
+      <div className="flex items-center justify-end gap-4 md:gap-9 divide-x divide-gray-300">
         <div className="flex pr-4 md:pr-9 items-center">
           {dashboardData && <DashBoardInfo dashboardId={dashboardData.id} />}
         </div>
-        <div className="flex">
+        <div className="flex ">
           <Profile />
         </div>
       </div>

--- a/src/components/dashboard/header/HeaderButton.tsx
+++ b/src/components/dashboard/header/HeaderButton.tsx
@@ -16,8 +16,16 @@ const HeaderButton = ({
   return (
     <Link href={href}>
       <div className="flex items-center gap-2 px-4 py-2 border border-gray-400 rounded-lg hover:bg-gray-200 transition-colors">
-        <Image src={icon} alt={`${icon} 아이콘`} width={20} height={20} />
-        <div className="font-medium text-[#787486]">{children}</div>
+        <Image
+          src={icon}
+          alt={`${icon} 아이콘`}
+          width={20}
+          height={20}
+          className="hidden md:block"
+        />
+        <div className="font-medium text-[#787486] whitespace-nowrap">
+          {children}
+        </div>
       </div>
     </Link>
   );

--- a/src/components/dashboard/header/HeaderButton.tsx
+++ b/src/components/dashboard/header/HeaderButton.tsx
@@ -1,12 +1,26 @@
+import Image from "next/image";
+import Link from "next/link";
 import { ButtonHTMLAttributes } from "react";
 
 interface HeaderButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  href?: string;
+  href: string;
+  icon: string;
 }
 
-// 대쉬보드 생성기능 완료 후 작업
-const HeaderButton = ({ children }: HeaderButtonProps) => {
-  return <button className="">{children}</button>;
+const HeaderButton = ({
+  children,
+  href,
+  icon,
+  ...props
+}: HeaderButtonProps) => {
+  return (
+    <Link href={href}>
+      <div className="flex items-center gap-2 px-4 py-2 border border-gray-400 rounded-lg hover:bg-gray-200 transition-colors">
+        <Image src={icon} alt={`${icon} 아이콘`} width={20} height={20} />
+        <div className="font-medium text-[#787486]">{children}</div>
+      </div>
+    </Link>
+  );
 };
 
 export default HeaderButton;

--- a/src/components/dashboard/header/HeaderButton.tsx
+++ b/src/components/dashboard/header/HeaderButton.tsx
@@ -7,12 +7,7 @@ interface HeaderButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   icon: string;
 }
 
-const HeaderButton = ({
-  children,
-  href,
-  icon,
-  ...props
-}: HeaderButtonProps) => {
+const HeaderButton = ({ children, href, icon }: HeaderButtonProps) => {
   return (
     <Link href={href}>
       <div className="flex items-center gap-2 px-4 py-2 border border-gray-400 rounded-lg hover:bg-gray-200 transition-colors">

--- a/src/components/ui/Avatar/index.tsx
+++ b/src/components/ui/Avatar/index.tsx
@@ -23,7 +23,7 @@ const Avatar = ({
 
   return (
     <figure
-      className={`w-[34px] md:w-[38px] aspect-square rounded-full overflow-hidden bg-black ${className}`}
+      className={`w-[34px] md:w-[38px] aspect-square rounded-full overflow-hidden bg-black border-2 border-white ${className}`}
       {...props}
     >
       {profileImageUrl ? (


### PR DESCRIPTION
## #️⃣ 이슈

- close #40 

## 📝 작업 내용
 - 대시보드 헤더의 버튼 구현.
 - 대시보드 헤더의 아바타스택 구현.
 - 대시보드 헤더의 ui 수정.


## 📸 결과물

## 👩‍💻 논의 사항
 - 헤더버튼의 경로 미설정. 페이지 구현후 설정 필요.
