### PR TITLE
Fix(#77) : 이미지 경고 해결.

### DIFF
--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -27,6 +27,7 @@ const Card = ({ card }: CardProps) => {
                 src={card.imageUrl}
                 alt="카드 이미지"
                 fill
+                sizes="160px"
                 className="object-cover rounded-lg"
               />
             </div>
@@ -57,6 +58,8 @@ const Card = ({ card }: CardProps) => {
                     <Image
                       src={"/column/calendar-icon.svg"}
                       alt="캘린더 아이콘"
+                      sizes="160px"
+                      priority
                       fill
                       className="object-cover"
                     />

--- a/src/components/card/CardDetailModal.tsx
+++ b/src/components/card/CardDetailModal.tsx
@@ -63,6 +63,7 @@ const CardDetailModal = ({ onClose, cardId }: CardDetailModalProps) => {
                 <Image
                   src="/column/close-icon.svg"
                   alt="모달 닫기 아이콘"
+                  sizes="100vw"
                   fill
                   className="object-cover"
                 />
@@ -132,6 +133,7 @@ const CardDetailModal = ({ onClose, cardId }: CardDetailModalProps) => {
                   <Image
                     src={cardData.imageUrl}
                     alt={`${cardData.title} 이미지`}
+                    sizes="100vw"
                     fill
                     className="object-cover"
                   />

--- a/src/components/dashboard/sidebar/SidebarBoardList.tsx
+++ b/src/components/dashboard/sidebar/SidebarBoardList.tsx
@@ -72,6 +72,7 @@ const SidebarBoardList = () => {
                     alt="왕관아이콘"
                     width={20}
                     height={20}
+                    style={{ width: "auto", height: "20px" }}
                   />
                 </div>
               )}

--- a/src/components/dashboard/sidebar/SidebarHeader.tsx
+++ b/src/components/dashboard/sidebar/SidebarHeader.tsx
@@ -10,13 +10,13 @@ const SidebarHeader = () => {
 
   return (
     <>
-      <div className="w-full flex items-center justify-center md:justify-between">
+      <div className="w-full p-2 flex items-center justify-center md:justify-between">
         <div className="hidden md:block text-sm lg:text-lg text-[#787486] font-semibold">
           Dash Boards
         </div>
         <button
           onClick={() => modalRef.current?.open()}
-          className="cursor-pointer hover:bg-gray-300 rounded-full p-2 transition-colors duration-300 ease-in-out"
+          className="cursor-pointer hover:bg-gray-300 rounded-full transition-colors duration-300 ease-in-out"
         >
           <Image
             src={"/dashboard/add-icon.svg"}

--- a/src/components/dashboard/sidebar/SidebarLogo.tsx
+++ b/src/components/dashboard/sidebar/SidebarLogo.tsx
@@ -16,6 +16,7 @@ const SidebarLogo = () => {
             alt="로고이미지"
             width={30}
             height={30}
+            style={{ width: "auto", height: "30px" }}
           />
         </div>
       </Link>

--- a/src/components/edit/InviteModal.tsx
+++ b/src/components/edit/InviteModal.tsx
@@ -57,6 +57,7 @@ const InviteModal = ({
             <Image
               src="/column/close-icon.svg"
               alt="닫기 아이콘"
+              sizes="100vw"
               fill
               className="object-contain"
             />

--- a/src/components/ui/Avatar/index.tsx
+++ b/src/components/ui/Avatar/index.tsx
@@ -30,6 +30,7 @@ const Avatar = ({
         <Image
           src={profileImageUrl}
           alt={userName}
+          sizes="100vw"
           fill
           className="object-cover"
         />

--- a/src/components/ui/Dropdown/index.tsx
+++ b/src/components/ui/Dropdown/index.tsx
@@ -47,6 +47,7 @@ const Dropdown = ({
           <Image
             src={icon ?? "/ui/kebabMenu-icon.svg"}
             alt="드롭다운 아이콘"
+            sizes="100vw"
             fill
             className="object-cover"
           />

--- a/src/components/ui/Field/ImageUpload.tsx
+++ b/src/components/ui/Field/ImageUpload.tsx
@@ -90,7 +90,13 @@ const ImageUpload = ({
 
         {preview && (
           <div className={clsx("relative", size)}>
-            <Image src={preview} alt="미리보기" fill className="object-cover" />
+            <Image
+              src={preview}
+              alt="미리보기"
+              sizes="100vw"
+              fill
+              className="object-cover"
+            />
             <button
               className="absolute top-0 right-0 flex items-center justify-center w-5 h-5 text-white bg-black rounded-full p-1 cursor-pointer"
               type="button"


### PR DESCRIPTION
## #️⃣ 이슈

- close #77 

## 📝 작업 내용
 - 카드이미지의 크기를 최적화.
 - 첫번쟤 인덱스 카드에 priority속성을 부여하여 최적화.

## 📸 결과물

## 👩‍💻 논의 사항
 - SidebarBoardList, HeaderButton에 있는 crown-icon, add-icon은 해결하지 못함. 부모 요소가 반응형으로 바뀌면서 다른 무언가 문제가 있는 듯함.
