### PR TITLE
fix: 시간 조절 함수 추가, 마감일 시간 수정

### DIFF
--- a/src/components/card/EditCardModal.tsx
+++ b/src/components/card/EditCardModal.tsx
@@ -13,7 +13,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useParams } from "next/navigation";
 import { useGetMembers } from "@/apis/members/queries";
 import { useUpdateCard } from "@/apis/cards/queries";
-import { formatDateForAPI } from "@/utils/formatDate";
+import { formatDateForCardAPI } from "@/utils/formatDate";
 import toast from "react-hot-toast";
 import StateInput from "../ui/Field/StateInput";
 import { Column } from "@/apis/columns/types";
@@ -97,7 +97,7 @@ const EditCardModal = ({
         ...data,
         dueDate:
           data.dueDate instanceof Date
-            ? formatDateForAPI(data.dueDate)
+            ? formatDateForCardAPI(data.dueDate)
             : data.dueDate,
         imageUrl: data.imageUrl || undefined,
       };

--- a/src/components/columns/CardModal.tsx
+++ b/src/components/columns/CardModal.tsx
@@ -13,7 +13,7 @@ import DateInput from "../ui/Field/DateInput";
 import TagInput from "../ui/Field/TagInput";
 import ImageUpload from "../ui/Field/ImageUpload";
 import toast from "react-hot-toast";
-import { formatDateForAPI } from "@/utils/formatDate";
+import { formatDateForCardAPI } from "@/utils/formatDate";
 import { useCreateCard } from "@/apis/cards/queries";
 import { usePostCardImage } from "@/apis/columns/queries";
 import { getErrorMessage } from "@/utils/network/errorMessage";
@@ -78,7 +78,7 @@ const CardModal = ({ onClose, columnId }: CardModalProps) => {
         ...data,
         dueDate:
           data.dueDate instanceof Date
-            ? formatDateForAPI(data.dueDate)
+            ? formatDateForCardAPI(data.dueDate)
             : data.dueDate,
         imageUrl: data.imageUrl as string | undefined,
       };

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -10,3 +10,17 @@ export const formatDateForAPI = (date: Date): string => {
 
   return `${year}-${month}-${day} ${hours}:${minutes}`;
 };
+
+export const formatDateForCardAPI = (date: Date): string => {
+  // 한국 시간대 보정 (+9시간)
+  const kstOffset = 9 * 60 * 60 * 1000; // 9시간
+  const kstTime = new Date(date.getTime() + kstOffset);
+
+  const year = kstTime.getUTCFullYear();
+  const month = String(kstTime.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(kstTime.getUTCDate()).padStart(2, "0");
+  const hours = String(kstTime.getUTCHours()).padStart(2, "0");
+  const minutes = String(kstTime.getUTCMinutes()).padStart(2, "0");
+
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
+};


### PR DESCRIPTION
## #️⃣ 이슈

- close #106 

## 📝 작업 내용
 - 시간 조절 함수 추가, 마감일 시간 수정

## 📸 결과물

## 👩‍💻 논의 사항
 - 백엔드 api 오류같다. 시간처리함수를 댓글과 마감일 같은 것을 쓰는데 댓글은 정상시간이고 마감일은 UTC시간으로 처리되어있음. +9시간 처리해주는 함수 생성하여 해결.